### PR TITLE
Add visitor counter and rating UI

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -17,6 +17,18 @@ DATA_FILE = os.path.join(os.path.dirname(__file__), "data", "simulated_responses
 with open(DATA_FILE, 'r', encoding='utf-8') as file:
     KNOWLEDGE_BASE = json.load(file)
 
+# Visitor count file
+COUNT_FILE = os.path.join(os.path.dirname(__file__), "data", "visitor_count.txt")
+if not os.path.exists(COUNT_FILE):
+    with open(COUNT_FILE, 'w') as f:
+        f.write('0')
+
+# Rating count file
+RATING_FILE = os.path.join(os.path.dirname(__file__), "data", "rating_counts.json")
+if not os.path.exists(RATING_FILE):
+    with open(RATING_FILE, 'w') as f:
+        json.dump({'happy': 0, 'neutral': 0, 'sad': 0}, f)
+
 # Route per ricevere le domande e rispondere
 @app.route('/chat', methods=['POST'])
 def chat():
@@ -31,6 +43,34 @@ def chat():
             return jsonify({'response': entry['risposta']})
 
     return jsonify({'response': "Lo siento, no tengo una respuesta para eso. ¿Puedes intentar preguntarlo de otra forma?"})
+
+# Route to increment and return visitor count
+@app.route('/visitor-count', methods=['GET'])
+def visitor_count():
+    with open(COUNT_FILE, 'r+') as f:
+        try:
+            count = int(f.read())
+        except ValueError:
+            count = 0
+        count += 1
+        f.seek(0)
+        f.write(str(count))
+        f.truncate()
+    return jsonify({'count': count})
+
+# Route to store customer rating
+@app.route('/rate', methods=['POST'])
+def rate():
+    data = request.get_json()
+    rating = data.get('rating')
+    with open(RATING_FILE, 'r+') as f:
+        counts = json.load(f)
+        if rating in counts:
+            counts[rating] += 1
+        f.seek(0)
+        json.dump(counts, f)
+        f.truncate()
+    return jsonify({'status': 'ok'})
 
 # Avvio dell'app sulla porta 5000, compatibile con Replit
 if __name__ == '__main__':

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -36,12 +36,26 @@
     button.send {
       width: 25%;
     }
-    #faq {
-      margin-top: 30px;
-      max-width: 800px;
-      margin-left: auto;
-      margin-right: auto;
-    }
+      #visitorCount {
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        font-size: 14px;
+      }
+      #rating {
+        margin-top: 20px;
+      }
+      #rating .face {
+        font-size: 2rem;
+        cursor: pointer;
+        margin: 0 5px;
+      }
+      #faq {
+        margin-top: 30px;
+        max-width: 800px;
+        margin-left: auto;
+        margin-right: auto;
+      }
     .faq-btn {
       display: block;
       background-color: #0078D4;
@@ -59,6 +73,7 @@
   </style>
 </head>
 <body>
+  <div id="visitorCount"></div>
   <h1>🍽️ Bienvenido a MENURIA ONE</h1>
   <p>Tu asistente virtual para el restaurante.</p>
 
@@ -66,6 +81,13 @@
     <div id="messages"></div>
     <input type="text" id="userInput" placeholder="Pregúntame algo..." />
     <button class="send" onclick="sendMessage()">Enviar</button>
+  </div>
+
+  <div id="rating">
+    <p>¿Cómo calificarías nuestro asistente?</p>
+    <span class="face" onclick="rate('happy')">😊</span>
+    <span class="face" onclick="rate('neutral')">😐</span>
+    <span class="face" onclick="rate('sad')">😞</span>
   </div>
 
   <div id="faq">
@@ -92,6 +114,16 @@
   </div>
 
   <script>
+    // Update visitor count when the page loads
+    fetch('/visitor-count')
+      .then(r => r.json())
+      .then(d => {
+        document.getElementById('visitorCount').textContent = 'Visitantes: ' + d.count;
+      })
+      .catch(() => {
+        document.getElementById('visitorCount').textContent = 'Visitantes: N/A';
+      });
+
     function sendMessage() {
       const input = document.getElementById('userInput');
       const message = input.value.trim();
@@ -122,10 +154,19 @@
       messages.scrollTop = messages.scrollHeight;
     }
 
-    function ask(question) {
-      document.getElementById('userInput').value = question;
-      sendMessage();
-    }
+  function ask(question) {
+    document.getElementById('userInput').value = question;
+    sendMessage();
+  }
+
+  function rate(feeling) {
+    fetch('/rate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rating: feeling })
+    }).catch(() => {});
+    alert('¡Gracias por tu valoración!');
+  }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add new Flask routes for visitor counter and rating persistence
- show visitor count at top-right of the page
- add rating section under the chat box

## Testing
- `python -m py_compile src/server.py src/bot.py`

------
https://chatgpt.com/codex/tasks/task_e_684c99026924833181dbee1000d28acd